### PR TITLE
Skip liborocos-kdl-dev and python3-pykdl for RHEL.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -13,7 +13,7 @@ tracks:
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc} --os-name rhel
+      :{release_inc} --os-name rhel --skip-keys liborocos-kdl-dev
     devel_branch: main
     last_version: 0.1.0
     name: upstream

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -13,7 +13,7 @@ tracks:
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc} --os-name rhel --skip-keys liborocos-kdl-dev
+      :{release_inc} --os-name rhel --skip-keys liborocos-kdl-dev python3-pykdl
     devel_branch: main
     last_version: 0.1.0
     name: upstream


### PR DESCRIPTION
This package isn't available at any version upstream but since this is a
vendor package it will build the vendored version for RHEL.